### PR TITLE
fix string split fuction

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -4,14 +4,22 @@
 
 #include <algorithm>  // std::max_element()
 
+namespace fuzz {
+
 namespace utils {
 
 int percent_round(double val);
+
 int intr(double val);
+
 vector<string> split_string(const string &str, const char c = ' ');
+
 string& trim(string &str);
+
 string join(const vector<string> &v, const string &sep = " ");
+
 string full_process(string str);
+
 size_t min(size_t a, size_t b);
 
 /*
@@ -31,5 +39,6 @@ auto max(const T &first, const Args&... args)
     return *max;
 }
 
+}  // utils utils
 
-}
+}  // utils fuzz

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+namespace fuzz {
+
 namespace utils {
 
 /*
@@ -27,15 +29,18 @@ int intr(double val)
 vector<string> split_string(const string &str, const char c)
 {
     vector<string> tokens;
+    string word;
+    for (const auto &len : str) {
+        if (len == c && word.size()) {
+            tokens.push_back(word);
+            word.clear();
+        } else if (len != c) {
+            word += len;
+        }
+    }
 
-    for (string::const_iterator len = str.begin(); len <= str.end(); len++) {
-        string::const_iterator token_start = len;
-
-        while (*len != c && *len) len++;
-        tokens.emplace_back(token_start, len);
-
-        /* we don't want strings of just whitespace; count past them. */
-        while (*len == c) len++;
+    if(word.size()) {
+        tokens.push_back(word);
     }
 
     return tokens;
@@ -107,4 +112,6 @@ size_t min(size_t a, size_t b)
     return a < b ? a : b;
 }
 
-}
+}  // ns utils
+
+}  // ns fuzz


### PR DESCRIPTION
the old split_string fuction when slipt the string: ```"I m in your mind"``` the result in the vector is
```{"I", "", "n", "our", "ind"}```
and not
```{"I", "m", "in", "your", "mind"}```