### PR TITLE
fix build fail on C++14

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -52,7 +52,7 @@ vector<string> split_string(const string &str, const char c)
  */
 string& trim(string &str)
 {
-    constexpr auto isspace = [](char ch) {
+    auto isspace = [](char ch) {
         /* NOTE: should we specify the locale? */
         return !std::isspace(ch);
     };


### PR DESCRIPTION
Hi, this PR enables people to build fuzzywuzzy by removing constexpr from a lambda. Which is a C++17 feature. 

If you think the constexpr should be there. I could also make a macro to enable constexpr lambda only when C++17 is available. 
Thank you.