### PR TITLE
Bugfix/empty str dedupe

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -85,8 +85,7 @@ vector<string> dedupe(const vector<string>& contains_dupes, int threshold, funct
         /* if there is only 1 item in *filtered*, no duplicates were found so append to *extracted* */
         if(filtered.size() == 1)
             extractor.push_back(*filtered.begin());
-        else if(filtered.size() == 0); //nop
-        else {
+        else if(filtered.size() != 0) {
             /* alpha sort */
             std::stable_sort(filtered.begin(), filtered.end(), [](const auto& a, const auto& b){ return a[0] > b[0]; });
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -85,6 +85,7 @@ vector<string> dedupe(const vector<string>& contains_dupes, int threshold, funct
         /* if there is only 1 item in *filtered*, no duplicates were found so append to *extracted* */
         if(filtered.size() == 1)
             extractor.push_back(*filtered.begin());
+        else if(filtered.size() == 0); //nop
         else {
             /* alpha sort */
             std::stable_sort(filtered.begin(), filtered.end(), [](const auto& a, const auto& b){ return a[0] > b[0]; });

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include "fuzzywuzzy.hpp"
+#include "process.hpp"
 
 int main()
 {
@@ -10,4 +11,7 @@ int main()
     std::cout << fuzz::ratio(a, b) << '\n';
     std::cout << fuzz::partial_ratio(a, b) << '\n';
     std::cout << fuzz::token_sort_ratio(c, d) << '\n';
+
+    std::vector<string> v = {"fuzzy", "wuzzy", "wuzzy", "fuzzy", "fuzzy", " "};
+    auto erg = fuzz::dedupe(v);
 }


### PR DESCRIPTION
When filtered has no elements, `extractor.push_back(*filtered.begin());` segfaults.

Which is a side effect of passing an empty string or a string with white-spaces only (that gets trimmed later on).

I am not 100% sure about this workaround but it passed my litmus test.